### PR TITLE
fix italian accented characters

### DIFF
--- a/src/main/java/spotify/setlist/util/SetlistUtils.java
+++ b/src/main/java/spotify/setlist/util/SetlistUtils.java
@@ -1,6 +1,7 @@
 package spotify.setlist.util;
 
 import java.net.MalformedURLException;
+import java.text.Normalizer;
 import java.text.SimpleDateFormat;
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -110,9 +111,13 @@ public class SetlistUtils {
    * @param input the input string
    * @return the purified string
    */
-  public static String purifyString(String input) {
-    return unGermanString(STRING_PURIFICATION_REGEX.matcher(input).replaceAll(" ").replaceAll("\\s+", " ")).trim();
-  }
+	public static String purifyString(String input) {
+
+		String step1 = unGermanString(STRING_PURIFICATION_REGEX.matcher(input).replaceAll(" ").replaceAll("\\s+", " "))
+				.trim();
+
+		return Normalizer.normalize(step1, Normalizer.Form.NFD).replaceAll("\\p{M}", "");
+	}
 
   /**
    * Returns true if the containedString is part of the baseString. Case is ignored.


### PR DESCRIPTION
Hi Selbi182, great work with this tool! Really amazing!
Just for fun I tried it with an italian setlist, and i realized 2 songs were missing. I add the playlist for your testing purposes:

https://www.setlist.fm/setlist/irene-grandi/2025/piazza-fiume-scandiano-italy-2b47402a.html

The 2 songs missing where "Sconvolto così" and "È solo un sogno".

I made a little correction in the way you purify strings, normalizing them (i.e. transforming ì to i).
The song was actually found by the api, even with the accents, but the containsIgnoreCaseNormalized failed, excluding the track from the results.